### PR TITLE
Fix the sorting for ticks left on overlay to handle buildings with unknown number of ticks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+web-ext-artifacts
 *.zip

--- a/chrome/overview.js
+++ b/chrome/overview.js
@@ -412,10 +412,24 @@ var COLUMN_SPECS = {
 				td.classList.add( 'red' );
 			else if ( n === 1 )
 				td.classList.add( 'yellow' );
+			else if ( isNaN(n) ) {
+				td.textContent = '';
+			}
 		},
 		sortId: 'tick',
 		sort: function( a, b ) {
-			return a.getTicksLeft() - b.getTicksLeft();
+			const aTicks = a.getTicksLeft();
+			const bTicks = b.getTicksLeft();
+			if (isNaN(aTicks) && isNaN(bTicks)) {
+				return 0;
+			}
+			if (isNaN(aTicks)) {
+				return -1;
+			}
+			if (isNaN(bTicks)) {
+				return 1;
+			}
+			return aTicks - bTicks;
 		}
 	},
 

--- a/chrome/overview.js
+++ b/chrome/overview.js
@@ -424,10 +424,10 @@ var COLUMN_SPECS = {
 				return 0;
 			}
 			if (isNaN(aTicks)) {
-				return -1;
+				return 1;
 			}
 			if (isNaN(bTicks)) {
-				return 1;
+				return -1;
 			}
 			return aTicks - bTicks;
 		}

--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    build: {
+        overwriteDest: true,
+    },
+    sourceDir: "chrome/"
+};


### PR DESCRIPTION
When some buildings have undefined ticks (due to not displaying all information on the building index, and/or not permitting trade), the sort function for ticks can result in multiple separately-sorted lists separated by the buildings with unknown ticks. This PR fixes this, so that all buildings with unknown ticks are sorted to the top (above the high-tick buildings), as it is presumed the user does not wish to see these buildings when trying to find 0, 1, and 2-tick buildings.